### PR TITLE
show overlay while dragging image over canvas

### DIFF
--- a/app.html
+++ b/app.html
@@ -18,6 +18,7 @@
     <div id="controller-container">
     </div>
     <div id="board-container">
+      <div id="dragging-overlay"></div>
       <div id="board" ></div>
     </div>
     <div id="run-container">

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -18,12 +18,35 @@ html, body {
   padding: 0;
   text-align: center;
 }
+#dragging-overlay:not(.activate) {
+  display: none;
+}
+#dragging-overlay {
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.7);
+  font-size: 2em;
+  color: white;
+  width: 480px;
+  height: 642px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  /* z-index で手前に持ってきているためこれがないと drop した時のイベントを受け取ってしまう
+   * (#board に渡したい)
+   */
+  pointer-events: none;
+}
 #board-container {
+  position: relative;
   width: 100%;
   height: 70%;
   margin-bottom: 5%;
   padding: 0;
   text-align: center;
+}
+#board {
+  z-index: 1;
 }
 #run-container {
   width: 100%;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -147,4 +147,22 @@ async function run () {
     container.appendChild(progress);
 }
 
+function registerDraggingMsg() {
+    const canvas = document.getElementsByTagName('canvas')[0];
+    canvas.addEventListener('dragover', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        $('#dragging-overlay').html(
+            'キャンバスサイズ<br>高さ ' + $(canvas).height() + 'px<br>×<br>幅 ' + $(canvas).height() + 'px'
+        );
+        $('#dragging-overlay').addClass('activate');
+    });
+    canvas.addEventListener('drop', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        $('#dragging-overlay').removeClass('activate');
+    });
+}
+
 document.getElementById('run').addEventListener('click', run);
+$(registerDraggingMsg);

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -23,6 +23,9 @@
         board.width(480);
         board.height(640);
     }
+
+    $('#dragging-overlay').width(board.width());
+    $('#dragging-overlay').height(board.height());
 })();
 
 var board = new DrawingBoard.Board('board', {
@@ -47,6 +50,7 @@ var board = new DrawingBoard.Board('board', {
     $('#run-container').width(width);
 
     $('#board').height($('#board-container').height());
+    $('#dragging-overlay').height($('#board').height());
 
     $('.drawing-board-controls').appendTo('#controller-container').removeAttr('data-align');
 


### PR DESCRIPTION
GIGAZINE 入りおめでとうございます 😄 
#2, #3 の辺りで試行錯誤しながら送るか迷った変更が手元にあったので送ってみます。

画像をドラッグ中、キャンバス上にある時はこんな感じでキャンバスサイズを表示します。
キャンバスサイズを書いておいた方が画像を合わせやすいかなというのと、テキストが「生成する」ボタン以外になかったので注意書き的な文言置くのは無粋かなと思って考えた結果でした。
ただそこまでの意図をユーザに汲み取ってもらえるかどうか微妙だなと思ったり… 何かいい案ありますでしょうか？

![image](https://user-images.githubusercontent.com/48169/46800913-12db0e80-cd94-11e8-914f-b3f74f4012c7.png)
