### PR TITLE
ドロップした画像をキャンバスサイズに合うよう拡大・縮小

### DIFF
--- a/static/js/init.js
+++ b/static/js/init.js
@@ -35,6 +35,7 @@ var board = new DrawingBoard.Board('board', {
     size: 10,
     enlargeYourContainer: true,
     droppable: true,
+    stretchImg: true,
 });
 
 (function () {


### PR DESCRIPTION
#1 で

> 本当はドロップした画像の位置を真ん中に来るよう調整したかったんですが、
> https://github.com/Leimi/drawingboard.js でそれをやる方法がパッと見て見つからなかったです…

って書いたんですが、 `stretchImg` ってオプションを見逃してました。